### PR TITLE
V0.3.1

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 import { ApolloProvider } from 'react-apollo'
 import { client } from './apollo/client'
-import { Route, Switch, BrowserRouter, Redirect } from 'react-router-dom'
+import { Route, Switch, HashRouter, Redirect } from 'react-router-dom'
 import GlobalPage from './pages/GlobalPage'
 import TokenPage from './pages/TokenPage'
 import PairPage from './pages/PairPage'
@@ -119,7 +119,7 @@ function App() {
         Object.keys(globalData).length > 0 &&
         globalChartData &&
         Object.keys(globalChartData).length > 0 ? (
-          <BrowserRouter>
+          <HashRouter>
             <Route component={GoogleAnalyticsReporter} />
             <Switch>
               <Route
@@ -203,7 +203,7 @@ function App() {
 
               <Redirect to="/home" />
             </Switch>
-          </BrowserRouter>
+          </HashRouter>
         ) : (
           <LocalLoader fill="true" />
         )}

--- a/src/pages/PairPage.js
+++ b/src/pages/PairPage.js
@@ -223,11 +223,7 @@ function PairPage({ pairAddress, history }) {
           </TYPE.body>
           {!below600 && <Search small={true} />}
         </RowBetween>
-        <WarningGrouping
-          disabled={
-            !dismissed && listedTokens && !(listedTokens.includes(token0?.id) && listedTokens.includes(token1?.id))
-          }
-        >
+
           <DashboardWrapper>
             <AutoColumn gap="40px" style={{ marginBottom: '1.5rem' }}>
               <div
@@ -502,7 +498,6 @@ function PairPage({ pairAddress, history }) {
               </Panel>
             </>
           </DashboardWrapper>
-        </WarningGrouping>
       </ContentWrapperLarge>
     </PageWrapper>
   )

--- a/src/pages/TokenPage.js
+++ b/src/pages/TokenPage.js
@@ -209,7 +209,6 @@ function TokenPage({ address, history }) {
           </AutoRow>
           {!below600 && <Search small={true} />}
         </RowBetween>
-        <WarningGrouping disabled={!dismissed && listedTokens && !listedTokens.includes(address)}>
           <DashboardWrapper style={{ marginTop: below1080 ? '0' : '1rem' }}>
             <RowBetween
               style={{
@@ -416,7 +415,6 @@ function TokenPage({ address, history }) {
               </Panel>
             </>
           </DashboardWrapper>
-        </WarningGrouping>
       </ContentWrapper>
     </PageWrapper>
   )


### PR DESCRIPTION
- Uses HashRouter instead of BrowserRouter so the dApp parses url inputs correctly when hosted on IPFS.

-Removed WarningGrouping elements that were disabling token and pair pages when loading pages by URL when hosted on IPFS.